### PR TITLE
Rename connector argument

### DIFF
--- a/tonic-tls/src/native/client.rs
+++ b/tonic-tls/src/native/client.rs
@@ -9,11 +9,11 @@ struct NativeConnector(tokio_native_tls::TlsConnector);
 
 impl crate::TlsConnector<TcpStream> for NativeConnector {
     type TlsStream = tokio_native_tls::TlsStream<TcpStream>;
-    type Domain = String;
+    type Arg = String;
 
     async fn connect(
         &self,
-        domain: Self::Domain,
+        domain: Self::Arg,
         stream: TcpStream,
     ) -> Result<Self::TlsStream, crate::Error> {
         self.0

--- a/tonic-tls/src/openssl/client.rs
+++ b/tonic-tls/src/openssl/client.rs
@@ -9,11 +9,11 @@ struct OpensslConnector(openssl::ssl::SslConnector);
 
 impl crate::TlsConnector<TcpStream> for OpensslConnector {
     type TlsStream = tokio_openssl::SslStream<TcpStream>;
-    type Domain = String;
+    type Arg = String;
 
     async fn connect(
         &self,
-        domain: Self::Domain,
+        domain: Self::Arg,
         stream: TcpStream,
     ) -> Result<Self::TlsStream, crate::Error> {
         let ssl_config = self.0.configure()?;

--- a/tonic-tls/src/rustls/client.rs
+++ b/tonic-tls/src/rustls/client.rs
@@ -10,11 +10,11 @@ struct RustlsConnector(tokio_rustls::TlsConnector);
 
 impl crate::TlsConnector<TcpStream> for RustlsConnector {
     type TlsStream = tokio_rustls::client::TlsStream<TcpStream>;
-    type Domain = tokio_rustls::rustls::pki_types::ServerName<'static>;
+    type Arg = tokio_rustls::rustls::pki_types::ServerName<'static>;
 
     async fn connect(
         &self,
-        domain: Self::Domain,
+        domain: Self::Arg,
         stream: TcpStream,
     ) -> Result<Self::TlsStream, crate::Error> {
         self.0

--- a/tonic-tls/src/schannel/client.rs
+++ b/tonic-tls/src/schannel/client.rs
@@ -12,18 +12,18 @@ struct SchannelConnector {
 
 impl crate::TlsConnector<TcpStream> for SchannelConnector {
     type TlsStream = tokio_schannel::TlsStream<TcpStream>;
-    type Domain = schannel::schannel_cred::SchannelCred;
+    type Arg = schannel::schannel_cred::SchannelCred;
 
     async fn connect(
         &self,
-        domain: schannel::schannel_cred::SchannelCred,
+        cred: schannel::schannel_cred::SchannelCred,
         stream: TcpStream,
     ) -> Result<Self::TlsStream, crate::Error> {
         // lock is needed because schannel inner is mutable
         self.inner
             .lock()
             .await
-            .connect(domain, stream)
+            .connect(cred, stream)
             .await
             .map_err(crate::Error::from)
     }


### PR DESCRIPTION
Different tls backends use different args.