### PR TITLE
TlsConnector struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ async fn run_openssl_tonic_server(
     tcp_s: tonic::transport::server::TcpIncoming,
     tls_acceptor: openssl::ssl::SslAcceptor,
 ) {
-let incoming = tonic_tls::openssl::incoming(tcp_s, tls_acceptor);
-let greeter = Greeter {};
-tonic::transport::Server::builder()
-    .add_service(helloworld::greeter_server::GreeterServer::new(greeter))
-    .serve_with_incoming(incoming)
-    .await
-    .unwrap();
+    let incoming = tonic_tls::openssl::TlsIncoming::new(tcp_s, tls_acceptor);
+    let greeter = OpensslGreeter {};
+    tonic::transport::Server::builder()
+        .add_service(helloworld::greeter_server::GreeterServer::new(greeter))
+        .serve_with_incoming(incoming)
+        .await
+        .unwrap();
 }
 ```
 
@@ -42,7 +42,7 @@ tonic::transport::Server::builder()
 // client example for openssl:
 async fn connect_tonic_channel(ssl_conn: openssl::ssl::SslConnector) {
     let ch: tonic::transport::Channel= tonic_tls::new_endpoint()
-        .connect_with_connector(tonic_tls::openssl::connector(
+        .connect_with_connector(tonic_tls::openssl::TlsConnector::new(
             "https://localhost:12345".parse().unwrap(),
             ssl_conn,
             "localhost".to_string(),

--- a/tonic-tls-tests/examples/client.rs
+++ b/tonic-tls-tests/examples/client.rs
@@ -20,7 +20,7 @@ async fn connect_tonic_channel(
     ssl_conn: openssl::ssl::SslConnector,
 ) -> Result<tonic::transport::Channel, tonic_tls::Error> {
     tonic_tls::new_endpoint()
-        .connect_with_connector(tonic_tls::openssl::connector(
+        .connect_with_connector(tonic_tls::openssl::TlsConnector::new(
             "https://localhost:50051".parse().unwrap(),
             ssl_conn,
             "localhost".to_string(), // server has cert with dns localhost

--- a/tonic-tls-tests/src/lib.rs
+++ b/tonic-tls-tests/src/lib.rs
@@ -90,7 +90,7 @@ mod tests {
             let dnsname = ServerName::try_from("localhost").unwrap();
 
             tonic_tls::new_endpoint()
-                .connect_with_connector(tonic_tls::rustls::connector(
+                .connect_with_connector(tonic_tls::rustls::TlsConnector::new(
                     url,
                     Arc::new(config),
                     dnsname,
@@ -285,7 +285,7 @@ mod tests {
             let url = format!("https://{}", addr).parse().unwrap();
             let dnsname = "localhost".to_string();
             tonic_tls::new_endpoint()
-                .connect_with_connector(tonic_tls::native::connector(url, tc, dnsname))
+                .connect_with_connector(tonic_tls::native::TlsConnector::new(url, tc, dnsname))
                 .await
                 .map_err(tonic_tls::Error::from)
         }
@@ -421,7 +421,9 @@ mod tests {
                 .unwrap();
             let dnsname = "localhost".to_string();
             tonic_tls::new_endpoint()
-                .connect_with_connector(tonic_tls::openssl::connector(url, connector, dnsname))
+                .connect_with_connector(tonic_tls::openssl::TlsConnector::new(
+                    url, connector, dnsname,
+                ))
                 .await
                 .map_err(tonic_tls::Error::from)
         }
@@ -658,7 +660,7 @@ mod tests {
                 .acquire(schannel::schannel_cred::Direction::Outbound)
                 .unwrap();
             tonic_tls::new_endpoint()
-                .connect_with_connector(tonic_tls::schannel::connector(url, builder, creds))
+                .connect_with_connector(tonic_tls::schannel::TlsConnector::new(url, builder, creds))
                 .await
                 .map_err(tonic_tls::Error::from)
         }

--- a/tonic-tls/src/lib.rs
+++ b/tonic-tls/src/lib.rs
@@ -36,7 +36,7 @@
 //! ```
 //! async fn connect_tonic_channel(ssl_conn: openssl::ssl::SslConnector){
 //!     let ch: tonic::transport::Channel= tonic_tls::new_endpoint()
-//!         .connect_with_connector(tonic_tls::openssl::connector(
+//!         .connect_with_connector(tonic_tls::openssl::TlsConnector::new(
 //!             "https:://localhost:12345".parse().unwrap(),
 //!             ssl_conn,
 //!            "localhost".to_string(),

--- a/tonic-tls/src/native/client.rs
+++ b/tonic-tls/src/native/client.rs
@@ -23,33 +23,68 @@ impl crate::TlsConnector<TcpStream> for NativeConnector {
     }
 }
 
-/// tonic client connector to connect to https endpoint at addr using
-/// native tls.
-/// domain is the server name to validate, and if none.
-/// Disabling validation is not supported.
-/// See [connect](tokio_native_tls::native_tls::TlsConnector::connect) for details.
-/// # Examples
-/// ```
-/// async fn connect_tonic_channel(ssl_conn: tokio_native_tls::native_tls::TlsConnector) -> tonic::transport::Channel {
-///     tonic_tls::new_endpoint()
-///         .connect_with_connector(tonic_tls::native::connector(
-///             "https:://localhost:12345".parse().unwrap(),
-///             ssl_conn,
-///             "localhost".to_string(),
-///         ))
-///         .await.unwrap()
-/// }
-/// ```
-pub fn connector(
+fn connector(
     uri: Uri,
     ssl_conn: tokio_native_tls::native_tls::TlsConnector,
     domain: String,
 ) -> impl Service<
     Uri,
-    Response = impl hyper::rt::Read + hyper::rt::Write + Send + Unpin + 'static,
+    Response = hyper_util::rt::TokioIo<tokio_native_tls::TlsStream<TcpStream>>,
     Future = impl Send + 'static,
     Error = crate::Error,
 > {
     let ssl_conn = NativeConnector(tokio_native_tls::TlsConnector::from(ssl_conn));
     crate::connector_inner(uri, ssl_conn, domain)
+}
+
+/// tonic client connector to connect to https endpoint at addr using
+/// native tls.
+pub struct TlsConnector {
+    inner: crate::client::ConnectorWrapper<tokio_native_tls::TlsStream<TcpStream>>,
+}
+
+impl TlsConnector {
+    /// domain is the server name to validate, and if none.
+    /// Disabling validation is not supported.
+    /// See [connect](tokio_native_tls::native_tls::TlsConnector::connect) for details.
+    /// # Examples
+    /// ```
+    /// async fn connect_tonic_channel(ssl_conn: tokio_native_tls::native_tls::TlsConnector) -> tonic::transport::Channel {
+    ///     tonic_tls::new_endpoint()
+    ///         .connect_with_connector(tonic_tls::native::TlsConnector::new(
+    ///             "https:://localhost:12345".parse().unwrap(),
+    ///             ssl_conn,
+    ///             "localhost".to_string(),
+    ///         ))
+    ///         .await.unwrap()
+    /// }
+    /// ```
+    pub fn new(
+        uri: Uri,
+        ssl_conn: tokio_native_tls::native_tls::TlsConnector,
+        domain: String,
+    ) -> Self {
+        Self {
+            inner: crate::client::ConnectorWrapper::new(connector(uri, ssl_conn, domain)),
+        }
+    }
+}
+
+impl Service<Uri> for TlsConnector {
+    type Response = hyper_util::rt::TokioIo<tokio_native_tls::TlsStream<TcpStream>>;
+
+    type Error = crate::Error;
+
+    type Future = futures::future::BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Uri) -> Self::Future {
+        self.inner.inner.call(req)
+    }
 }

--- a/tonic-tls/src/native/mod.rs
+++ b/tonic-tls/src/native/mod.rs
@@ -9,7 +9,7 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tokio_native_tls::{TlsAcceptor, TlsStream};
 
 mod client;
-pub use client::connector;
+pub use client::TlsConnector;
 mod server;
 pub use server::TlsIncoming;
 

--- a/tonic-tls/src/openssl/client.rs
+++ b/tonic-tls/src/openssl/client.rs
@@ -26,32 +26,63 @@ impl crate::TlsConnector<TcpStream> for OpensslConnector {
     }
 }
 
-/// tonic client connector to connect to https endpoint at addr using
-/// openssl settings in ssl.
-/// domain is the server name to validate.
-/// See [connect](openssl::ssl::SslConnector::connect) for details.
-/// # Examples
-/// ```
-/// async fn connect_tonic_channel(ssl_conn: openssl::ssl::SslConnector){
-///     let ch: tonic::transport::Channel = tonic_tls::new_endpoint()
-///         .connect_with_connector(tonic_tls::openssl::connector(
-///             "https:://localhost:12345".parse().unwrap(),
-///             ssl_conn,
-///            "localhost".to_string(),
-///         ))
-///         .await.unwrap();
-/// }
-/// ```
-pub fn connector(
+fn connector(
     uri: Uri,
     ssl_conn: openssl::ssl::SslConnector,
     domain: String,
 ) -> impl Service<
     Uri,
-    Response = impl hyper::rt::Read + hyper::rt::Write + Send + Unpin + 'static,
+    Response = hyper_util::rt::TokioIo<tokio_openssl::SslStream<TcpStream>>,
     Future = impl Send + 'static,
     Error = crate::Error,
 > {
     let ssl_conn = OpensslConnector(ssl_conn);
     crate::connector_inner(uri, ssl_conn, domain)
+}
+
+/// tonic client connector to connect to https endpoint at addr using
+/// openssl settings in ssl.
+pub struct TlsConnector {
+    inner: crate::client::ConnectorWrapper<tokio_openssl::SslStream<TcpStream>>,
+}
+
+impl TlsConnector {
+    /// domain is the server name to validate.
+    /// See [connect](openssl::ssl::SslConnector::connect) for details.
+    /// # Examples
+    /// ```
+    /// async fn connect_tonic_channel(ssl_conn: openssl::ssl::SslConnector){
+    ///     let ch: tonic::transport::Channel = tonic_tls::new_endpoint()
+    ///         .connect_with_connector(tonic_tls::openssl::TlsConnector::new(
+    ///             "https:://localhost:12345".parse().unwrap(),
+    ///             ssl_conn,
+    ///            "localhost".to_string(),
+    ///         ))
+    ///         .await.unwrap();
+    /// }
+    /// ```
+    pub fn new(uri: Uri, ssl_conn: openssl::ssl::SslConnector, domain: String) -> Self {
+        Self {
+            inner: crate::client::ConnectorWrapper::new(connector(uri, ssl_conn, domain)),
+        }
+    }
+}
+
+impl Service<Uri> for TlsConnector {
+    type Response = hyper_util::rt::TokioIo<tokio_openssl::SslStream<TcpStream>>;
+
+    type Error = crate::Error;
+
+    type Future = futures::future::BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Uri) -> Self::Future {
+        self.inner.inner.call(req)
+    }
 }

--- a/tonic-tls/src/openssl/mod.rs
+++ b/tonic-tls/src/openssl/mod.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tonic::transport::server::Connected;
 
 mod client;
-pub use client::connector;
+pub use client::TlsConnector;
 mod server;
 pub use server::TlsIncoming;
 

--- a/tonic-tls/src/rustls/client.rs
+++ b/tonic-tls/src/rustls/client.rs
@@ -4,12 +4,14 @@ use tokio::net::TcpStream;
 use tonic::transport::Uri;
 use tower::Service;
 
+pub type TlsStream = tokio_rustls::client::TlsStream<TcpStream>;
+
 /// Internal implementation of connector wrapper.
 #[derive(Clone)]
 struct RustlsConnector(tokio_rustls::TlsConnector);
 
 impl crate::TlsConnector<TcpStream> for RustlsConnector {
-    type TlsStream = tokio_rustls::client::TlsStream<TcpStream>;
+    type TlsStream = TlsStream;
     type Arg = tokio_rustls::rustls::pki_types::ServerName<'static>;
 
     async fn connect(
@@ -24,34 +26,69 @@ impl crate::TlsConnector<TcpStream> for RustlsConnector {
     }
 }
 
-/// tonic client connector to connect to https endpoint at addr using
-/// rustls.
-/// domain is the server name to validate.
-/// Disabling validation is not supported.
-/// See [connect](tokio_rustls::TlsConnector::connect) for details.
-/// # Examples
-/// ```
-/// async fn connect_tonic_channel(ssl_conn: std::sync::Arc<tokio_rustls::rustls::ClientConfig>) -> tonic::transport::Channel {
-///     let dnsname = tokio_rustls::rustls::pki_types::ServerName::try_from("localhost").unwrap();
-///     tonic_tls::new_endpoint()
-///         .connect_with_connector(tonic_tls::rustls::connector(
-///             "https:://localhost:12345".parse().unwrap(),
-///             ssl_conn,
-///             dnsname,
-///         ))
-///         .await.unwrap()
-/// }
-/// ```
-pub fn connector(
+fn connector(
     uri: Uri,
     ssl_conn: Arc<tokio_rustls::rustls::ClientConfig>,
     domain: tokio_rustls::rustls::pki_types::ServerName<'static>,
 ) -> impl Service<
     Uri,
-    Response = impl hyper::rt::Read + hyper::rt::Write + Send + Unpin + 'static,
+    Response = hyper_util::rt::TokioIo<TlsStream>,
     Future = impl Send + 'static,
     Error = crate::Error,
 > {
     let ssl_conn = RustlsConnector(tokio_rustls::TlsConnector::from(ssl_conn));
     crate::connector_inner(uri, ssl_conn, domain)
+}
+
+/// tonic client connector to connect to https endpoint at addr using
+/// rustls.
+pub struct TlsConnector {
+    inner: crate::client::ConnectorWrapper<TlsStream>,
+}
+
+impl TlsConnector {
+    /// domain is the server name to validate.
+    /// Disabling validation is not supported.
+    /// See [connect](tokio_rustls::TlsConnector::connect) for details.
+    /// # Examples
+    /// ```
+    /// async fn connect_tonic_channel(ssl_conn: std::sync::Arc<tokio_rustls::rustls::ClientConfig>) -> tonic::transport::Channel {
+    ///     let dnsname = tokio_rustls::rustls::pki_types::ServerName::try_from("localhost").unwrap();
+    ///     tonic_tls::new_endpoint()
+    ///         .connect_with_connector(tonic_tls::rustls::TlsConnector::new(
+    ///             "https:://localhost:12345".parse().unwrap(),
+    ///             ssl_conn,
+    ///             dnsname,
+    ///         ))
+    ///         .await.unwrap()
+    /// }
+    /// ```
+    pub fn new(
+        uri: Uri,
+        ssl_conn: Arc<tokio_rustls::rustls::ClientConfig>,
+        domain: tokio_rustls::rustls::pki_types::ServerName<'static>,
+    ) -> Self {
+        Self {
+            inner: crate::client::ConnectorWrapper::new(connector(uri, ssl_conn, domain)),
+        }
+    }
+}
+
+impl Service<Uri> for TlsConnector {
+    type Response = hyper_util::rt::TokioIo<TlsStream>;
+
+    type Error = crate::Error;
+
+    type Future = futures::future::BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Uri) -> Self::Future {
+        self.inner.inner.call(req)
+    }
 }

--- a/tonic-tls/src/rustls/mod.rs
+++ b/tonic-tls/src/rustls/mod.rs
@@ -10,7 +10,7 @@ use tokio_rustls::rustls::pki_types::CertificateDer;
 use tonic::transport::server::Connected;
 
 mod client;
-pub use client::connector;
+pub use client::TlsConnector;
 mod server;
 pub use server::TlsIncoming;
 

--- a/tonic-tls/src/schannel/mod.rs
+++ b/tonic-tls/src/schannel/mod.rs
@@ -10,7 +10,7 @@ use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tonic::transport::server::Connected;
 
 mod client;
-pub use client::connector;
+pub use client::TlsConnector;
 mod server;
 pub use server::TlsIncoming;
 


### PR DESCRIPTION
Wrap tower service connector into BoxedService.
Original connector() function is replaced by TlsConnector struct. TlsConnector is easier to use than the previous impl return.
 