### PR TITLE
Pass tcp options from tonic endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 *.info
 codecov.json
+.vscode

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,7 @@ dependencies = [
  "hyper-util",
  "openssl",
  "schannel",
+ "socket2",
  "tokio",
  "tokio-native-tls",
  "tokio-openssl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "async-stream"
@@ -79,9 +79,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "axum"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core",
  "bytes",
@@ -124,9 +124,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -145,9 +145,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "bytes"
@@ -157,9 +157,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
 dependencies = [
  "shlex",
 ]
@@ -188,9 +188,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "deranged"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cfac68e08048ae1883171632c2aef3ebc555621ae56fbccce1cbf22dd7f058"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
 ]
@@ -209,9 +209,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -313,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -324,9 +324,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
@@ -342,9 +342,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.8"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
 name = "heck"
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -498,15 +498,15 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -534,29 +534,29 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff70ce3e48ae43fa075863cef62e8b43b71a4f2382229920e0df362592919430"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "multimap"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "native-tls"
@@ -598,9 +598,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -630,9 +630,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
@@ -712,9 +712,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -722,9 +722,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -846,7 +846,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -860,9 +860,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags",
  "errno",
@@ -873,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "once_cell",
  "ring",
@@ -887,15 +887,18 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -904,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "schannel"
@@ -968,9 +971,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -986,9 +989,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
@@ -1008,9 +1011,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1025,12 +1028,12 @@ checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -1057,9 +1060,9 @@ checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "tokio"
-version = "1.44.1"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f382da615b842244d4b8738c82ed1275e6c5dd90c459a30941cd07080b06c91a"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1137,9 +1140,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1150,9 +1153,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85839f0b32fd242bb3209262371d07feda6d780d16ee9d2bc88581b89da1549b"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
  "axum",
@@ -1179,9 +1182,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d85f0383fadd15609306383a90e85eaed44169f931a5d2be1b42c76ceff1825e"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
 dependencies = [
  "prettyplease",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ tower = "0.5"
 hyper = "1"
 hyper-util = "0.1"
 tracing = "0.1"
+socket2 = "0.5"
 
 # native tls
 tokio-native-tls = "0.3"

--- a/tonic-tls-tests/examples/client.rs
+++ b/tonic-tls-tests/examples/client.rs
@@ -19,14 +19,14 @@ async fn main() -> Result<(), tonic_tls::Error> {
 async fn connect_tonic_channel(
     ssl_conn: openssl::ssl::SslConnector,
 ) -> Result<tonic::transport::Channel, tonic_tls::Error> {
-    tonic_tls::new_endpoint()
-        .connect_with_connector(tonic_tls::openssl::TlsConnector::new(
-            "https://localhost:50051".parse().unwrap(),
-            ssl_conn,
-            "localhost".to_string(), // server has cert with dns localhost
-        ))
-        .await
-        .map_err(tonic_tls::Error::from)
+    let ep = tonic::transport::Endpoint::from_static("https://localhost:50051");
+    ep.connect_with_connector(tonic_tls::openssl::TlsConnector::new(
+        &ep,
+        ssl_conn,
+        "localhost".to_string(), // server has cert with dns localhost
+    ))
+    .await
+    .map_err(tonic_tls::Error::from)
 }
 
 fn make_ssl_conn() -> openssl::ssl::SslConnector {

--- a/tonic-tls/Cargo.toml
+++ b/tonic-tls/Cargo.toml
@@ -16,6 +16,7 @@ tokio.workspace = true
 async-stream.workspace = true
 tracing.workspace = true
 futures.workspace = true
+socket2.workspace = true
 
 tower.workspace = true
 tonic.workspace = true

--- a/tonic-tls/src/endpoint.rs
+++ b/tonic-tls/src/endpoint.rs
@@ -2,6 +2,8 @@ use std::time::Duration;
 
 use hyper::Uri;
 
+/// Data and options needed from [Endpoint](tonic::transport::Endpoint)
+/// in tls connector layer.
 pub(crate) struct TcpOpt {
     pub(crate) uri: Uri,
     // interval is not supported in tonic yet.
@@ -10,6 +12,7 @@ pub(crate) struct TcpOpt {
 }
 
 impl TcpOpt {
+    /// Extract relevant info from endpoint.
     pub(crate) fn from_ep(ep: &tonic::transport::Endpoint) -> Self {
         Self {
             keep_alive_duration: ep.get_tcp_keepalive(),
@@ -18,7 +21,7 @@ impl TcpOpt {
         }
     }
 
-    // apply the tcp options to stream.
+    /// Apply the tcp options to stream.
     pub(crate) fn apply_opt(&self, tcp: &tokio::net::TcpStream) -> std::io::Result<()> {
         if self.no_delay {
             tcp.set_nodelay(true)?;

--- a/tonic-tls/src/endpoint.rs
+++ b/tonic-tls/src/endpoint.rs
@@ -1,0 +1,33 @@
+use std::time::Duration;
+
+use hyper::Uri;
+
+pub(crate) struct TcpOpt {
+    pub(crate) uri: Uri,
+    // interval is not supported in tonic yet.
+    pub(crate) keep_alive_duration: Option<Duration>,
+    pub(crate) no_delay: bool,
+}
+
+impl TcpOpt {
+    pub(crate) fn from_ep(ep: &tonic::transport::Endpoint) -> Self {
+        Self {
+            keep_alive_duration: ep.get_tcp_keepalive(),
+            no_delay: ep.get_tcp_nodelay(),
+            uri: ep.uri().clone(),
+        }
+    }
+
+    // apply the tcp options to stream.
+    pub(crate) fn apply_opt(&self, tcp: &tokio::net::TcpStream) -> std::io::Result<()> {
+        if self.no_delay {
+            tcp.set_nodelay(true)?;
+        }
+        if let Some(keep_alive_duration) = self.keep_alive_duration {
+            let ka = socket2::TcpKeepalive::new().with_time(keep_alive_duration);
+            let sf = socket2::SockRef::from(&tcp);
+            sf.set_tcp_keepalive(&ka)?
+        }
+        Ok(())
+    }
+}

--- a/tonic-tls/src/lib.rs
+++ b/tonic-tls/src/lib.rs
@@ -34,14 +34,15 @@
 //! ```
 //! Client example:
 //! ```
-//! async fn connect_tonic_channel(ssl_conn: openssl::ssl::SslConnector){
-//!     let ch: tonic::transport::Channel= tonic_tls::new_endpoint()
-//!         .connect_with_connector(tonic_tls::openssl::TlsConnector::new(
-//!             "https:://localhost:12345".parse().unwrap(),
-//!             ssl_conn,
-//!            "localhost".to_string(),
-//!         ))
-//!         .await.unwrap();
+//! async fn connect_tonic_channel(
+//!     endpoint: tonic::transport::Endpoint,
+//!     ssl_conn: openssl::ssl::SslConnector
+//! ) -> tonic::transport::Channel {
+//!     endpoint.connect_with_connector(tonic_tls::openssl::TlsConnector::new(
+//!         &endpoint,
+//!         ssl_conn,
+//!        "localhost".to_string(),
+//!     )).await.unwrap()
 //! }
 //! ```
 #![doc(html_root_url = "https://docs.rs/tonic-tls/latest/tonic_tls/")]
@@ -54,9 +55,10 @@ use std::{ops::ControlFlow, pin::pin};
 use futures::Stream;
 use tokio::io::{AsyncRead, AsyncWrite};
 mod client;
-pub use client::{connector_inner, new_endpoint, TlsConnector};
+pub use client::{connector_inner, TlsConnector};
 mod server;
 use server::TlsIncoming;
+mod endpoint;
 
 #[cfg(feature = "native")]
 pub mod native;

--- a/tonic-tls/src/native/client.rs
+++ b/tonic-tls/src/native/client.rs
@@ -24,7 +24,7 @@ impl crate::TlsConnector<TcpStream> for NativeConnector {
 }
 
 fn connector(
-    uri: Uri,
+    endpoint: &tonic::transport::Endpoint,
     ssl_conn: tokio_native_tls::native_tls::TlsConnector,
     domain: String,
 ) -> impl Service<
@@ -34,7 +34,7 @@ fn connector(
     Error = crate::Error,
 > {
     let ssl_conn = NativeConnector(tokio_native_tls::TlsConnector::from(ssl_conn));
-    crate::connector_inner(uri, ssl_conn, domain)
+    crate::connector_inner(endpoint, ssl_conn, domain)
 }
 
 /// tonic client connector to connect to https endpoint at addr using
@@ -49,23 +49,24 @@ impl TlsConnector {
     /// See [connect](tokio_native_tls::native_tls::TlsConnector::connect) for details.
     /// # Examples
     /// ```
-    /// async fn connect_tonic_channel(ssl_conn: tokio_native_tls::native_tls::TlsConnector) -> tonic::transport::Channel {
-    ///     tonic_tls::new_endpoint()
-    ///         .connect_with_connector(tonic_tls::native::TlsConnector::new(
-    ///             "https:://localhost:12345".parse().unwrap(),
-    ///             ssl_conn,
-    ///             "localhost".to_string(),
-    ///         ))
-    ///         .await.unwrap()
+    /// async fn connect_tonic_channel(
+    ///     endpoint: tonic::transport::Endpoint,
+    ///     ssl_conn: tokio_native_tls::native_tls::TlsConnector)
+    /// -> tonic::transport::Channel {
+    ///     endpoint.connect_with_connector(tonic_tls::native::TlsConnector::new(
+    ///         &endpoint,
+    ///         ssl_conn,
+    ///         "localhost".to_string(),
+    ///     )).await.unwrap()
     /// }
     /// ```
     pub fn new(
-        uri: Uri,
+        endpoint: &tonic::transport::Endpoint,
         ssl_conn: tokio_native_tls::native_tls::TlsConnector,
         domain: String,
     ) -> Self {
         Self {
-            inner: crate::client::ConnectorWrapper::new(connector(uri, ssl_conn, domain)),
+            inner: crate::client::ConnectorWrapper::new(connector(endpoint, ssl_conn, domain)),
         }
     }
 }

--- a/tonic-tls/src/openssl/client.rs
+++ b/tonic-tls/src/openssl/client.rs
@@ -27,7 +27,7 @@ impl crate::TlsConnector<TcpStream> for OpensslConnector {
 }
 
 fn connector(
-    uri: Uri,
+    endpoint: &tonic::transport::Endpoint,
     ssl_conn: openssl::ssl::SslConnector,
     domain: String,
 ) -> impl Service<
@@ -37,7 +37,7 @@ fn connector(
     Error = crate::Error,
 > {
     let ssl_conn = OpensslConnector(ssl_conn);
-    crate::connector_inner(uri, ssl_conn, domain)
+    crate::connector_inner(endpoint, ssl_conn, domain)
 }
 
 /// tonic client connector to connect to https endpoint at addr using
@@ -51,19 +51,24 @@ impl TlsConnector {
     /// See [connect](openssl::ssl::SslConnector::connect) for details.
     /// # Examples
     /// ```
-    /// async fn connect_tonic_channel(ssl_conn: openssl::ssl::SslConnector){
-    ///     let ch: tonic::transport::Channel = tonic_tls::new_endpoint()
-    ///         .connect_with_connector(tonic_tls::openssl::TlsConnector::new(
-    ///             "https:://localhost:12345".parse().unwrap(),
-    ///             ssl_conn,
-    ///            "localhost".to_string(),
-    ///         ))
-    ///         .await.unwrap();
+    /// async fn connect_tonic_channel(
+    ///     endpoint: tonic::transport::Endpoint,
+    ///     ssl_conn: openssl::ssl::SslConnector
+    /// ) -> tonic::transport::Channel {
+    ///     endpoint.connect_with_connector(tonic_tls::openssl::TlsConnector::new(
+    ///         &endpoint,
+    ///         ssl_conn,
+    ///        "localhost".to_string(),
+    ///     )).await.unwrap()
     /// }
     /// ```
-    pub fn new(uri: Uri, ssl_conn: openssl::ssl::SslConnector, domain: String) -> Self {
+    pub fn new(
+        endpoint: &tonic::transport::Endpoint,
+        ssl_conn: openssl::ssl::SslConnector,
+        domain: String,
+    ) -> Self {
         Self {
-            inner: crate::client::ConnectorWrapper::new(connector(uri, ssl_conn, domain)),
+            inner: crate::client::ConnectorWrapper::new(connector(endpoint, ssl_conn, domain)),
         }
     }
 }

--- a/tonic-tls/src/schannel/client.rs
+++ b/tonic-tls/src/schannel/client.rs
@@ -32,7 +32,7 @@ impl crate::TlsConnector<TcpStream> for SchannelConnector {
 }
 
 fn connector(
-    uri: Uri,
+    endpoint: &tonic::transport::Endpoint,
     builder: schannel::tls_stream::Builder,
     cred: schannel::schannel_cred::SchannelCred,
 ) -> impl Service<
@@ -46,7 +46,7 @@ fn connector(
             builder,
         ))),
     };
-    crate::connector_inner(uri, ssl_conn, cred)
+    crate::connector_inner(endpoint, ssl_conn, cred)
 }
 
 /// tonic client connector to connect to https endpoint at addr using
@@ -59,25 +59,25 @@ impl TlsConnector {
     /// See [connect](schannel::tls_stream::Builder::connect) for details.
     /// # Examples
     /// ```
-    /// async fn connect_tonic_channel(builder: schannel::tls_stream::Builder,
-    ///         cred: schannel::schannel_cred::SchannelCred)
+    /// async fn connect_tonic_channel(
+    ///     endpoint: tonic::transport::Endpoint,
+    ///     builder: schannel::tls_stream::Builder,
+    ///     cred: schannel::schannel_cred::SchannelCred)
     /// -> tonic::transport::Channel {
-    ///     tonic_tls::new_endpoint()
-    ///         .connect_with_connector(tonic_tls::schannel::TlsConnector::new(
-    ///             "https:://localhost:12345".parse().unwrap(),
-    ///             builder,
-    ///             cred,
-    ///         ))
-    ///         .await.unwrap()
+    ///     endpoint.connect_with_connector(tonic_tls::schannel::TlsConnector::new(
+    ///         &endpoint,
+    ///         builder,
+    ///         cred,
+    ///     )).await.unwrap()
     /// }
     /// ```
     pub fn new(
-        uri: Uri,
+        endpoint: &tonic::transport::Endpoint,
         builder: schannel::tls_stream::Builder,
         cred: schannel::schannel_cred::SchannelCred,
     ) -> Self {
         Self {
-            inner: crate::client::ConnectorWrapper::new(connector(uri, builder, cred)),
+            inner: crate::client::ConnectorWrapper::new(connector(endpoint, builder, cred)),
         }
     }
 }


### PR DESCRIPTION
Tonic endpoint tcp options like no delay and keep alive are ignored by custom connectors that tonic-tls relies on.
This PR sets the tcp options on tcp connections specified by tonic endpoint.