### PR TITLE
Remove sync and debug bounds for streams

### DIFF
--- a/tonic-tls/src/client.rs
+++ b/tonic-tls/src/client.rs
@@ -14,7 +14,7 @@ use crate::endpoint::TcpOpt;
 /// To add a new tls backend, implement this and pass it into [connector_inner].
 pub trait TlsConnector<S>: Clone + Send + 'static
 where
-    S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type TlsStream;
     /// Argument for connect.
@@ -30,7 +30,7 @@ where
 /// Implement this for custom transports (e.g. Unix sockets, VSOCK).
 pub trait Transport: Clone + Send + 'static {
     /// The connection type produced by this transport.
-    type Io: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static;
+    type Io: AsyncRead + AsyncWrite + Send + Unpin + 'static;
     /// The error type returned by connect.
     type Error: Into<crate::Error>;
 
@@ -76,7 +76,7 @@ pub fn connector_inner<T, C, TS>(transport: T, ssl_conn: C, arg: C::Arg) -> TlsB
 where
     T: Transport,
     C: TlsConnector<T::Io, TlsStream = TS>,
-    TS: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    TS: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     let svc = tower::service_fn(move |uri: Uri| {
         let transport = transport.clone();

--- a/tonic-tls/src/native/client.rs
+++ b/tonic-tls/src/native/client.rs
@@ -9,7 +9,7 @@ struct NativeConnector(tokio_native_tls::TlsConnector);
 
 impl<S> crate::TlsConnector<S> for NativeConnector
 where
-    S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type TlsStream = tokio_native_tls::TlsStream<S>;
     type Arg = String;
@@ -28,7 +28,7 @@ pub struct TlsConnector<IO> {
     inner: crate::client::TlsBoxedService<tokio_native_tls::TlsStream<IO>>,
 }
 
-impl<IO: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static> TlsConnector<IO> {
+impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
     /// domain is the server name to validate, and if none.
     /// Disabling validation is not supported.
     /// See [connect](tokio_native_tls::native_tls::TlsConnector::connect) for details.

--- a/tonic-tls/src/native/server.rs
+++ b/tonic-tls/src/native/server.rs
@@ -16,7 +16,7 @@ impl NativeTlsAcceptor {
 
 impl<S> crate::server::TlsAcceptor<S> for NativeTlsAcceptor
 where
-    S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type TlsStream = TlsStreamWrapper<S>;
     async fn accept(&self, stream: S) -> Result<TlsStreamWrapper<S>, crate::Error> {
@@ -34,7 +34,7 @@ pub struct TlsIncoming<IO> {
     inner: crate::server::TlsIncoming<TlsStreamWrapper<IO>>,
 }
 
-impl<IO: AsyncRead + AsyncWrite + Send + Sync + std::fmt::Debug + Unpin + 'static> TlsIncoming<IO> {
+impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsIncoming<IO> {
     /// Creates a tls incoming stream on top of an incoming stream
     /// # Examples
     /// ```no_run

--- a/tonic-tls/src/openssl/client.rs
+++ b/tonic-tls/src/openssl/client.rs
@@ -9,7 +9,7 @@ struct OpensslConnector(openssl::ssl::SslConnector);
 
 impl<S> crate::TlsConnector<S> for OpensslConnector
 where
-    S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type TlsStream = tokio_openssl::SslStream<S>;
     type Arg = String;
@@ -31,7 +31,7 @@ pub struct TlsConnector<IO> {
     inner: crate::client::TlsBoxedService<tokio_openssl::SslStream<IO>>,
 }
 
-impl<IO: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static> TlsConnector<IO> {
+impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
     /// domain is the server name to validate.
     /// See [connect](openssl::ssl::SslConnector::connect) for details.
     /// # Examples

--- a/tonic-tls/src/openssl/server.rs
+++ b/tonic-tls/src/openssl/server.rs
@@ -17,7 +17,7 @@ impl OpensslTlsAcceptor {
 
 impl<S> crate::server::TlsAcceptor<S> for OpensslTlsAcceptor
 where
-    S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type TlsStream = SslStream<S>;
     async fn accept(&self, stream: S) -> Result<SslStream<S>, crate::Error> {
@@ -34,7 +34,7 @@ pub struct TlsIncoming<IO> {
     inner: crate::server::TlsIncoming<SslStream<IO>>,
 }
 
-impl<IO: AsyncRead + AsyncWrite + Send + Sync + std::fmt::Debug + Unpin + 'static> TlsIncoming<IO> {
+impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsIncoming<IO> {
     /// Creates a tls incoming stream on top of an incoming stream
     /// # Examples
     /// ```no_run

--- a/tonic-tls/src/rustls/client.rs
+++ b/tonic-tls/src/rustls/client.rs
@@ -12,7 +12,7 @@ struct RustlsConnector(tokio_rustls::TlsConnector);
 
 impl<S> crate::TlsConnector<S> for RustlsConnector
 where
-    S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type TlsStream = TlsStream<S>;
     type Arg = tokio_rustls::rustls::pki_types::ServerName<'static>;
@@ -31,7 +31,7 @@ pub struct TlsConnector<IO> {
     inner: crate::client::TlsBoxedService<TlsStream<IO>>,
 }
 
-impl<IO: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static> TlsConnector<IO> {
+impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
     /// domain is the server name to validate.
     /// Disabling validation is not supported.
     /// See [connect](tokio_rustls::TlsConnector::connect) for details.

--- a/tonic-tls/src/rustls/server.rs
+++ b/tonic-tls/src/rustls/server.rs
@@ -16,7 +16,7 @@ impl RustlsAcceptor {
 
 impl<S> crate::server::TlsAcceptor<S> for RustlsAcceptor
 where
-    S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type TlsStream = TlsStream<S>;
     async fn accept(&self, stream: S) -> Result<TlsStream<S>, crate::Error> {
@@ -34,7 +34,7 @@ pub struct TlsIncoming<IO> {
     inner: crate::server::TlsIncoming<TlsStream<IO>>,
 }
 
-impl<IO: AsyncRead + AsyncWrite + Send + Sync + std::fmt::Debug + Unpin + 'static> TlsIncoming<IO> {
+impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsIncoming<IO> {
     /// Creates a tls incoming stream on top of an incoming stream
     /// # Examples
     /// ```no_run

--- a/tonic-tls/src/schannel/client.rs
+++ b/tonic-tls/src/schannel/client.rs
@@ -14,7 +14,7 @@ struct SchannelConnector {
 
 impl<S> crate::TlsConnector<S> for SchannelConnector
 where
-    S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type TlsStream = TlsStream<S>;
     type Arg = schannel::schannel_cred::SchannelCred;
@@ -40,7 +40,7 @@ pub struct TlsConnector<IO> {
     inner: crate::client::TlsBoxedService<TlsStream<IO>>,
 }
 
-impl<IO: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static> TlsConnector<IO> {
+impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
     /// See [connect](schannel::tls_stream::Builder::connect) for details.
     /// # Examples
     /// ```

--- a/tonic-tls/src/schannel/server.rs
+++ b/tonic-tls/src/schannel/server.rs
@@ -25,7 +25,7 @@ impl SchannelAcceptor {
 
 impl<S> crate::server::TlsAcceptor<S> for SchannelAcceptor
 where
-    S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type TlsStream = TlsStream<S>;
     async fn accept(&self, stream: S) -> Result<TlsStream<S>, crate::Error> {
@@ -46,7 +46,7 @@ pub struct TlsIncoming<IO> {
     inner: crate::server::TlsIncoming<TlsStream<IO>>,
 }
 
-impl<IO: AsyncRead + AsyncWrite + Send + Sync + std::fmt::Debug + Unpin + 'static> TlsIncoming<IO> {
+impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsIncoming<IO> {
     /// Creates a tls incoming stream on top of an incoming stream
     /// # Examples
     /// ```no_run

--- a/tonic-tls/src/server.rs
+++ b/tonic-tls/src/server.rs
@@ -1,5 +1,4 @@
 use futures::TryStreamExt;
-use std::fmt::Debug;
 use std::io;
 use std::{ops::ControlFlow, pin::pin};
 
@@ -16,7 +15,7 @@ pub(crate) type TlsIncoming<TS> = futures::stream::BoxStream<'static, Result<TS,
 /// implementation needs to be passed to [incoming_inner].
 pub trait TlsAcceptor<S>: Clone + Send + 'static
 where
-    S: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static,
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type TlsStream;
     fn accept(
@@ -29,7 +28,7 @@ where
 /// Implement this for custom transports (e.g. Unix sockets, VSOCK).
 pub trait Incoming: Stream<Item = Result<Self::Io, Self::Error>> + Send + 'static {
     /// The connection type yielded by the stream.
-    type Io: AsyncRead + AsyncWrite + Send + Sync + Debug + Unpin + 'static;
+    type Io: AsyncRead + AsyncWrite + Send + Unpin + 'static;
     /// The error type yielded by the stream.
     type Error: Into<crate::Error>;
 }


### PR DESCRIPTION
Sync and Debug are not required by tonic incoming stream trait requirements.