### PR TITLE
Make all TLS client connectors cloneable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1498,7 +1498,7 @@ dependencies = [
 
 [[package]]
 name = "tonic-tls"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "async-stream",
  "futures",

--- a/docs/Transport-trait.md
+++ b/docs/Transport-trait.md
@@ -6,7 +6,7 @@ transport, not just TCP (e.g. Unix sockets, VSOCK, named pipes).
 ## Trait definition
 
 ```rust
-pub trait Transport: Clone + Send + 'static {
+pub trait Transport: Clone + Send + Sync + 'static {
     type Io: AsyncRead + AsyncWrite + Send + Sync + Unpin + 'static;
     type Error: Into<crate::Error>;
 

--- a/tonic-tls-tests/src/ktls_tests.rs
+++ b/tonic-tls-tests/src/ktls_tests.rs
@@ -42,31 +42,13 @@ async fn connect_openssl_ktls_tonic_channel(
     cert: &openssl::x509::X509,
     addr: SocketAddr,
 ) -> Result<Channel, tonic_tls::Error> {
-    let mut connector =
-        openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls()).unwrap();
-    connector.cert_store_mut().add_cert(cert.clone()).unwrap();
-    connector.add_client_ca(cert).unwrap();
-    connector.set_verify_callback(openssl::ssl::SslVerifyMode::PEER, |ok, ctx| {
-        if !ok {
-            let e = ctx.error();
-            println!("verify failed : {e}");
-        }
-        ok
-    });
-    connector
-        .set_alpn_protos(tonic_tls::openssl::ALPN_H2_WIRE)
-        .unwrap();
-    let connector = connector.build();
     // use dns to test resolve
     let url = format!("https://localhost:{}", addr.port());
-    let dnsname = "localhost".to_string();
     let ep = tonic::transport::Endpoint::from_shared(url).unwrap();
-    let transport = tonic_tls::TcpTransport::from_endpoint(&ep);
-    ep.connect_with_connector(tonic_tls::openssl_ktls::TlsConnector::new(
-        transport, connector, dnsname,
-    ))
-    .await
-    .map_err(tonic_tls::Error::from)
+    let connector = make_openssl_ktls_connector(cert, &ep);
+    ep.connect_with_connector(connector)
+        .await
+        .map_err(tonic_tls::Error::from)
 }
 pub fn create_openssl_ktls_acceptor(
     cert: &openssl::x509::X509,
@@ -171,6 +153,71 @@ async fn openssl_ktls_test() {
     println!("RESPONSE={resp:?}");
 
     // stop server
+    sv_token.cancel();
+    sv_h.await.unwrap();
+}
+
+fn make_openssl_ktls_connector(
+    cert: &openssl::x509::X509,
+    ep: &tonic::transport::Endpoint,
+) -> tonic_tls::openssl_ktls::TlsConnector {
+    let mut connector =
+        openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls()).unwrap();
+    connector.cert_store_mut().add_cert(cert.clone()).unwrap();
+    connector.add_client_ca(cert).unwrap();
+    connector.set_verify_callback(openssl::ssl::SslVerifyMode::PEER, |ok, ctx| {
+        if !ok {
+            let e = ctx.error();
+            println!("verify failed : {e}");
+        }
+        ok
+    });
+    connector
+        .set_alpn_protos(tonic_tls::openssl::ALPN_H2_WIRE)
+        .unwrap();
+    let connector = connector.build();
+    let transport = tonic_tls::TcpTransport::from_endpoint(ep);
+    tonic_tls::openssl_ktls::TlsConnector::new(transport, connector, "localhost".to_string())
+}
+
+/// The connector is cloneable, so it can be created once and reused by
+/// multiple tonic endpoints via clones.
+#[tokio::test]
+async fn openssl_ktls_connector_clone_test() {
+    let (cert, key) = crate::tests::make_test_cert2(vec!["localhost".to_string()]);
+
+    let (listener, addr) = crate::tests::create_listener_server().await;
+
+    let sv_token = CancellationToken::new();
+    let sv_token_cp = sv_token.clone();
+
+    let acceptor = create_openssl_ktls_acceptor(&cert, &key);
+    let sv_h = tokio::spawn(async move {
+        run_openssl_ktls_tonic_server(sv_token_cp, TcpIncoming::from(listener), acceptor).await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let url = format!("https://localhost:{}", addr.port());
+    let ep = tonic::transport::Endpoint::from_shared(url).unwrap();
+    let connector = make_openssl_ktls_connector(&cert, &ep);
+    // clone the connector and use each clone on a separate endpoint.
+    let connector_cp = connector.clone();
+
+    for conn in [connector, connector_cp] {
+        let ch = ep
+            .clone()
+            .connect_with_connector(conn)
+            .await
+            .expect("cannot connect");
+        let mut client = helloworld::greeter_client::GreeterClient::new(ch);
+        let request = tonic::Request::new(helloworld::HelloRequest {
+            name: "Tonic".into(),
+        });
+        let resp = client.say_hello(request).await.unwrap();
+        assert_eq!(resp.into_inner().message, "Hello Tonic!");
+    }
+
     sv_token.cancel();
     sv_h.await.unwrap();
 }

--- a/tonic-tls-tests/src/ntls_tests.rs
+++ b/tonic-tls-tests/src/ntls_tests.rs
@@ -65,21 +65,14 @@ async fn connect_ntls_tonic_channel(
     cert: &native_tls::Certificate,
     addr: SocketAddr,
 ) -> Result<Channel, tonic_tls::Error> {
-    let tc = native_tls::TlsConnector::builder()
-        .disable_built_in_roots(true)
-        .add_root_certificate(cert.clone())
-        .request_alpns(&[std::str::from_utf8(tonic_tls::ALPN_H2).unwrap()])
-        .build()
-        .unwrap();
     let url = format!("https://{addr}");
-    let dnsname = "localhost".to_string();
     let ep = tonic::transport::Endpoint::from_shared(url)
         .unwrap()
         .tcp_keepalive(Some(Duration::from_secs(5)))
         .tcp_keepalive_interval(Some(Duration::from_secs(3)))
         .tcp_keepalive_retries(Some(3));
-    let transport = tonic_tls::TcpTransport::from_endpoint(&ep);
-    ep.connect_with_connector(tonic_tls::native::TlsConnector::new(transport, tc, dnsname))
+    let connector = make_ntls_connector(cert, &ep);
+    ep.connect_with_connector(connector)
         .await
         .map_err(tonic_tls::Error::from)
 }
@@ -162,6 +155,62 @@ async fn ntls_test() {
     println!("RESPONSE={resp:?}");
 
     // stop server
+    sv_token.cancel();
+    sv_h.await.unwrap();
+}
+
+fn make_ntls_connector(
+    cert: &native_tls::Certificate,
+    ep: &tonic::transport::Endpoint,
+) -> tonic_tls::native::TlsConnector<tokio::net::TcpStream> {
+    let tc = native_tls::TlsConnector::builder()
+        .disable_built_in_roots(true)
+        .add_root_certificate(cert.clone())
+        .request_alpns(&[std::str::from_utf8(tonic_tls::ALPN_H2).unwrap()])
+        .build()
+        .unwrap();
+    let transport = tonic_tls::TcpTransport::from_endpoint(ep);
+    tonic_tls::native::TlsConnector::new(transport, tc, "localhost".to_string())
+}
+
+/// The connector is cloneable, so it can be created once and reused by
+/// multiple tonic endpoints via clones.
+#[tokio::test]
+async fn ntls_connector_clone_test() {
+    let (cert, key) = make_test_cert_ntls(vec!["localhost".to_string()]);
+
+    let (listener, addr) = crate::tests::create_listener_server().await;
+
+    let sv_token = CancellationToken::new();
+    let sv_token_cp = sv_token.clone();
+
+    let acceptor = create_ntls_acceptor(&key);
+    let sv_h = tokio::spawn(async move {
+        run_ntls_tonic_server(sv_token_cp, TcpIncoming::from(listener), acceptor).await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let url = format!("https://{addr}");
+    let ep = tonic::transport::Endpoint::from_shared(url).unwrap();
+    let connector = make_ntls_connector(&cert, &ep);
+    // clone the connector and use each clone on a separate endpoint.
+    let connector_cp = connector.clone();
+
+    for conn in [connector, connector_cp] {
+        let ch = ep
+            .clone()
+            .connect_with_connector(conn)
+            .await
+            .expect("cannot connect");
+        let mut client = helloworld::greeter_client::GreeterClient::new(ch);
+        let request = tonic::Request::new(helloworld::HelloRequest {
+            name: "Tonic".into(),
+        });
+        let resp = client.say_hello(request).await.unwrap();
+        assert_eq!(resp.into_inner().message, "Hello Tonic!");
+    }
+
     sv_token.cancel();
     sv_h.await.unwrap();
 }

--- a/tonic-tls-tests/src/openssl_tests.rs
+++ b/tonic-tls-tests/src/openssl_tests.rs
@@ -38,31 +38,13 @@ async fn connect_openssl_tonic_channel(
     cert: &openssl::x509::X509,
     addr: SocketAddr,
 ) -> Result<Channel, tonic_tls::Error> {
-    let mut connector =
-        openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls()).unwrap();
-    connector.cert_store_mut().add_cert(cert.clone()).unwrap();
-    connector.add_client_ca(cert).unwrap();
-    connector.set_verify_callback(openssl::ssl::SslVerifyMode::PEER, |ok, ctx| {
-        if !ok {
-            let e = ctx.error();
-            println!("verify failed : {e}");
-        }
-        ok
-    });
-    connector
-        .set_alpn_protos(tonic_tls::openssl::ALPN_H2_WIRE)
-        .unwrap();
-    let connector = connector.build();
     // use dns to test resolve
     let url = format!("https://localhost:{}", addr.port());
-    let dnsname = "localhost".to_string();
     let ep = tonic::transport::Endpoint::from_shared(url).unwrap();
-    let transport = tonic_tls::TcpTransport::from_endpoint(&ep);
-    ep.connect_with_connector(tonic_tls::openssl::TlsConnector::new(
-        transport, connector, dnsname,
-    ))
-    .await
-    .map_err(tonic_tls::Error::from)
+    let connector = make_openssl_connector(cert, &ep);
+    ep.connect_with_connector(connector)
+        .await
+        .map_err(tonic_tls::Error::from)
 }
 
 pub fn create_openssl_acceptor(
@@ -169,6 +151,71 @@ async fn openssl_test() {
     println!("RESPONSE={resp:?}");
 
     // stop server
+    sv_token.cancel();
+    sv_h.await.unwrap();
+}
+
+fn make_openssl_connector(
+    cert: &openssl::x509::X509,
+    ep: &tonic::transport::Endpoint,
+) -> tonic_tls::openssl::TlsConnector<tokio::net::TcpStream> {
+    let mut connector =
+        openssl::ssl::SslConnector::builder(openssl::ssl::SslMethod::tls()).unwrap();
+    connector.cert_store_mut().add_cert(cert.clone()).unwrap();
+    connector.add_client_ca(cert).unwrap();
+    connector.set_verify_callback(openssl::ssl::SslVerifyMode::PEER, |ok, ctx| {
+        if !ok {
+            let e = ctx.error();
+            println!("verify failed : {e}");
+        }
+        ok
+    });
+    connector
+        .set_alpn_protos(tonic_tls::openssl::ALPN_H2_WIRE)
+        .unwrap();
+    let connector = connector.build();
+    let transport = tonic_tls::TcpTransport::from_endpoint(ep);
+    tonic_tls::openssl::TlsConnector::new(transport, connector, "localhost".to_string())
+}
+
+/// The connector is cloneable, so it can be created once and reused by
+/// multiple tonic endpoints via clones.
+#[tokio::test]
+async fn openssl_connector_clone_test() {
+    let (cert, key) = crate::tests::make_test_cert2(vec!["localhost".to_string()]);
+
+    let (listener, addr) = crate::tests::create_listener_server().await;
+
+    let sv_token = CancellationToken::new();
+    let sv_token_cp = sv_token.clone();
+
+    let acceptor = create_openssl_acceptor(&cert, &key);
+    let sv_h = tokio::spawn(async move {
+        run_openssl_tonic_server(sv_token_cp, TcpIncoming::from(listener), acceptor).await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let url = format!("https://localhost:{}", addr.port());
+    let ep = tonic::transport::Endpoint::from_shared(url).unwrap();
+    let connector = make_openssl_connector(&cert, &ep);
+    // clone the connector and use each clone on a separate endpoint.
+    let connector_cp = connector.clone();
+
+    for conn in [connector, connector_cp] {
+        let ch = ep
+            .clone()
+            .connect_with_connector(conn)
+            .await
+            .expect("cannot connect");
+        let mut client = helloworld::greeter_client::GreeterClient::new(ch);
+        let request = tonic::Request::new(helloworld::HelloRequest {
+            name: "Tonic".into(),
+        });
+        let resp = client.say_hello(request).await.unwrap();
+        assert_eq!(resp.into_inner().message, "Hello Tonic!");
+    }
+
     sv_token.cancel();
     sv_h.await.unwrap();
 }

--- a/tonic-tls-tests/src/rustls_tests.rs
+++ b/tonic-tls-tests/src/rustls_tests.rs
@@ -43,9 +43,20 @@ async fn connect_rustls_tonic_channel(
     cert: &CertificateDer<'static>,
     addr: SocketAddr,
 ) -> Result<Channel, tonic_tls::Error> {
+    let url = format!("https://{addr}");
+    let ep = tonic::transport::Endpoint::from_shared(url).unwrap();
+    let connector = make_rustls_connector(cert, &ep);
+    ep.connect_with_connector(connector)
+        .await
+        .map_err(tonic_tls::Error::from)
+}
+
+fn make_rustls_connector(
+    cert: &CertificateDer<'static>,
+    ep: &tonic::transport::Endpoint,
+) -> tonic_tls::rustls::TlsConnector<tokio::net::TcpStream> {
     use tokio_rustls::rustls::{ClientConfig, RootCertStore, pki_types::ServerName};
 
-    let url = format!("https://{addr}");
     let mut root_cert_store = RootCertStore::empty();
     root_cert_store.add(cert.clone()).unwrap();
     let mut config = ClientConfig::builder()
@@ -54,16 +65,8 @@ async fn connect_rustls_tonic_channel(
     config.alpn_protocols = vec![tonic_tls::ALPN_H2.to_vec()];
 
     let dnsname = ServerName::try_from("localhost").unwrap();
-
-    let ep = tonic::transport::Endpoint::from_shared(url).unwrap();
-    let transport = tonic_tls::TcpTransport::from_endpoint(&ep);
-    ep.connect_with_connector(tonic_tls::rustls::TlsConnector::new(
-        transport,
-        Arc::new(config),
-        dnsname,
-    ))
-    .await
-    .map_err(tonic_tls::Error::from)
+    let transport = tonic_tls::TcpTransport::from_endpoint(ep);
+    tonic_tls::rustls::TlsConnector::new(transport, Arc::new(config), dnsname)
 }
 
 fn make_test_cert_rustls(
@@ -178,6 +181,48 @@ async fn rustls_test() {
     println!("RESPONSE={resp:?}");
 
     // stop server
+    sv_token.cancel();
+    sv_h.await.unwrap();
+}
+
+/// The connector is cloneable, so it can be created once and reused by
+/// multiple tonic endpoints via clones.
+#[tokio::test]
+async fn rustls_connector_clone_test() {
+    let (cert, key) = make_test_cert_rustls(vec!["localhost".to_string()]);
+
+    let (listener, addr) = crate::tests::create_listener_server().await;
+
+    let sv_token = CancellationToken::new();
+    let sv_token_cp = sv_token.clone();
+
+    let acceptor = create_rustls_acceptor(&cert, &key);
+    let sv_h = tokio::spawn(async move {
+        run_rustls_tonic_server(sv_token_cp, TcpIncoming::from(listener), acceptor).await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let url = format!("https://{addr}");
+    let ep = tonic::transport::Endpoint::from_shared(url).unwrap();
+    let connector = make_rustls_connector(&cert, &ep);
+    // clone the connector and use each clone on a separate endpoint.
+    let connector_cp = connector.clone();
+
+    for conn in [connector, connector_cp] {
+        let ch = ep
+            .clone()
+            .connect_with_connector(conn)
+            .await
+            .expect("cannot connect");
+        let mut client = helloworld::greeter_client::GreeterClient::new(ch);
+        let request = tonic::Request::new(helloworld::HelloRequest {
+            name: "Tonic".into(),
+        });
+        let resp = client.say_hello(request).await.unwrap();
+        assert_eq!(resp.into_inner().message, "Hello Tonic!");
+    }
+
     sv_token.cancel();
     sv_h.await.unwrap();
 }

--- a/tonic-tls-tests/src/schannel_tests.rs
+++ b/tonic-tls-tests/src/schannel_tests.rs
@@ -104,10 +104,10 @@ pub fn in_mem_key(
     Ok(context)
 }
 
-async fn connect_schannel_tonic_channel(
+fn make_schannel_connector(
     root: &schannel::cert_context::CertContext,
-    addr: SocketAddr,
-) -> Result<Channel, tonic_tls::Error> {
+    ep: &tonic::transport::Endpoint,
+) -> tonic_tls::schannel::TlsConnector<tokio::net::TcpStream> {
     let mut builder = schannel::tls_stream::Builder::new();
     builder.verify_callback(|ctx| {
         if let Err(e) = ctx.result() {
@@ -124,18 +124,24 @@ async fn connect_schannel_tonic_channel(
     builder.cert_store(cert_store);
     builder.request_application_protocols(&[tonic_tls::ALPN_H2]);
 
-    let url = format!("https://{addr}");
     let creds = schannel::schannel_cred::SchannelCred::builder()
         .acquire(schannel::schannel_cred::Direction::Outbound)
         .unwrap();
-    let ep = tonic::transport::Endpoint::from_shared(url).unwrap();
 
-    let transport = tonic_tls::TcpTransport::from_endpoint(&ep);
-    ep.connect_with_connector(tonic_tls::schannel::TlsConnector::new(
-        transport, builder, creds,
-    ))
-    .await
-    .map_err(tonic_tls::Error::from)
+    let transport = tonic_tls::TcpTransport::from_endpoint(ep);
+    tonic_tls::schannel::TlsConnector::new(transport, builder, creds)
+}
+
+async fn connect_schannel_tonic_channel(
+    root: &schannel::cert_context::CertContext,
+    addr: SocketAddr,
+) -> Result<Channel, tonic_tls::Error> {
+    let url = format!("https://{addr}");
+    let ep = tonic::transport::Endpoint::from_shared(url).unwrap();
+    let connector = make_schannel_connector(root, &ep);
+    ep.connect_with_connector(connector)
+        .await
+        .map_err(tonic_tls::Error::from)
 }
 pub fn create_schannel_acceptor() -> schannel::tls_stream::Builder {
     let mut builder = schannel::tls_stream::Builder::new();
@@ -239,6 +245,52 @@ async fn schannel_test() {
     println!("RESPONSE={resp:?}");
 
     // stop server
+    sv_token.cancel();
+    sv_h.await.unwrap();
+}
+
+/// The connector is cloneable, so it can be created once and reused by
+/// multiple tonic endpoints via clones.
+#[tokio::test]
+async fn schannel_connector_clone_test() {
+    let (cert, key) = make_test_cert_schannel(vec!["localhost".to_string()]);
+
+    let (listener, addr) = crate::tests::create_listener_server().await;
+
+    let sv_token = CancellationToken::new();
+    let sv_token_cp = sv_token.clone();
+
+    let creds = schannel::schannel_cred::SchannelCred::builder()
+        .cert(key.clone())
+        .acquire(schannel::schannel_cred::Direction::Inbound)
+        .unwrap();
+    let acceptor = create_schannel_acceptor();
+    let sv_h = tokio::spawn(async move {
+        run_schannel_tonic_server(sv_token_cp, TcpIncoming::from(listener), acceptor, creds).await
+    });
+
+    tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+    let url = format!("https://{addr}");
+    let ep = tonic::transport::Endpoint::from_shared(url).unwrap();
+    let connector = make_schannel_connector(&cert, &ep);
+    // clone the connector and use each clone on a separate endpoint.
+    let connector_cp = connector.clone();
+
+    for conn in [connector, connector_cp] {
+        let ch = ep
+            .clone()
+            .connect_with_connector(conn)
+            .await
+            .expect("cannot connect");
+        let mut client = helloworld::greeter_client::GreeterClient::new(ch);
+        let request = tonic::Request::new(helloworld::HelloRequest {
+            name: "Tonic".into(),
+        });
+        let resp = client.say_hello(request).await.unwrap();
+        assert_eq!(resp.into_inner().message, "Hello Tonic!");
+    }
+
     sv_token.cancel();
     sv_h.await.unwrap();
 }

--- a/tonic-tls/Cargo.toml
+++ b/tonic-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tonic-tls"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 license = "MIT"
 authors = ["youyuanwu@outlook.com"]

--- a/tonic-tls/src/client.rs
+++ b/tonic-tls/src/client.rs
@@ -28,7 +28,7 @@ where
 
 /// Trait for abstracting the transport connection step.
 /// Implement this for custom transports (e.g. Unix sockets, VSOCK).
-pub trait Transport: Clone + Send + 'static {
+pub trait Transport: Clone + Send + Sync + 'static {
     /// The connection type produced by this transport.
     type Io: AsyncRead + AsyncWrite + Send + Unpin + 'static;
     /// The error type returned by connect.
@@ -74,7 +74,7 @@ pub(crate) type TlsBoxedService<TS> =
 /// Applications should use the tls backend api, for example [super::openssl::TlsConnector]
 pub fn connector_inner<T, C, TS>(transport: T, ssl_conn: C, arg: C::Arg) -> TlsBoxedService<TS>
 where
-    T: Transport + Sync,
+    T: Transport,
     C: TlsConnector<T::Io, TlsStream = TS> + Sync,
     C::Arg: Sync,
     TS: AsyncRead + AsyncWrite + Send + Unpin + 'static,

--- a/tonic-tls/src/client.rs
+++ b/tonic-tls/src/client.rs
@@ -68,14 +68,15 @@ impl Transport for TcpTransport {
 }
 
 pub(crate) type TlsBoxedService<TS> =
-    tower::util::BoxService<Uri, hyper_util::rt::TokioIo<TS>, crate::Error>;
+    tower::util::BoxCloneSyncService<Uri, hyper_util::rt::TokioIo<TS>, crate::Error>;
 
 /// Not intended to be used by applications directly.
 /// Applications should use the tls backend api, for example [super::openssl::TlsConnector]
 pub fn connector_inner<T, C, TS>(transport: T, ssl_conn: C, arg: C::Arg) -> TlsBoxedService<TS>
 where
-    T: Transport,
-    C: TlsConnector<T::Io, TlsStream = TS>,
+    T: Transport + Sync,
+    C: TlsConnector<T::Io, TlsStream = TS> + Sync,
+    C::Arg: Sync,
     TS: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     let svc = tower::service_fn(move |uri: Uri| {
@@ -88,7 +89,7 @@ where
             Ok::<_, crate::Error>(hyper_util::rt::TokioIo::new(ssl_s))
         }
     });
-    tower::util::BoxService::new(svc)
+    tower::util::BoxCloneSyncService::new(svc)
 }
 
 /// Use the host:port portion of the uri and resolve to an sockaddr.

--- a/tonic-tls/src/client.rs
+++ b/tonic-tls/src/client.rs
@@ -12,13 +12,13 @@ use crate::endpoint::TcpOpt;
 
 /// Not intended to be used by applications directly.
 /// To add a new tls backend, implement this and pass it into [connector_inner].
-pub trait TlsConnector<S>: Clone + Send + 'static
+pub trait TlsConnector<S>: Clone + Send + Sync + 'static
 where
     S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     type TlsStream;
     /// Argument for connect.
-    type Arg: Clone + Send;
+    type Arg: Clone + Send + Sync;
     fn connect(
         &self,
         arg: Self::Arg,
@@ -75,8 +75,7 @@ pub(crate) type TlsBoxedService<TS> =
 pub fn connector_inner<T, C, TS>(transport: T, ssl_conn: C, arg: C::Arg) -> TlsBoxedService<TS>
 where
     T: Transport,
-    C: TlsConnector<T::Io, TlsStream = TS> + Sync,
-    C::Arg: Sync,
+    C: TlsConnector<T::Io, TlsStream = TS>,
     TS: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
     let svc = tower::service_fn(move |uri: Uri| {

--- a/tonic-tls/src/native/client.rs
+++ b/tonic-tls/src/native/client.rs
@@ -24,8 +24,21 @@ where
 
 /// tonic client connector to connect to https endpoint at addr using
 /// native tls.
+///
+/// The connector is cloneable, so it can be created once and cloned to be
+/// passed to separate tonic endpoints or other consumers. Clones connect
+/// independently and share the same tls configuration.
 pub struct TlsConnector<IO> {
     inner: crate::client::TlsBoxedService<tokio_native_tls::TlsStream<IO>>,
+}
+
+// Manual impl because IO does not need to be Clone.
+impl<IO> Clone for TlsConnector<IO> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
@@ -47,7 +60,7 @@ impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
     /// }
     /// ```
     pub fn new(
-        transport: impl crate::Transport<Io = IO>,
+        transport: impl crate::Transport<Io = IO> + Sync,
         ssl_conn: tokio_native_tls::native_tls::TlsConnector,
         domain: String,
     ) -> Self {

--- a/tonic-tls/src/native/client.rs
+++ b/tonic-tls/src/native/client.rs
@@ -60,7 +60,7 @@ impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
     /// }
     /// ```
     pub fn new(
-        transport: impl crate::Transport<Io = IO> + Sync,
+        transport: impl crate::Transport<Io = IO>,
         ssl_conn: tokio_native_tls::native_tls::TlsConnector,
         domain: String,
     ) -> Self {

--- a/tonic-tls/src/openssl/client.rs
+++ b/tonic-tls/src/openssl/client.rs
@@ -62,7 +62,7 @@ impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
     /// }
     /// ```
     pub fn new(
-        transport: impl crate::Transport<Io = IO> + Sync,
+        transport: impl crate::Transport<Io = IO>,
         ssl_conn: openssl::ssl::SslConnector,
         domain: String,
     ) -> Self {

--- a/tonic-tls/src/openssl/client.rs
+++ b/tonic-tls/src/openssl/client.rs
@@ -27,8 +27,21 @@ where
 
 /// tonic client connector to connect to https endpoint at addr using
 /// openssl settings in ssl.
+///
+/// The connector is cloneable, so it can be created once and cloned to be
+/// passed to separate tonic endpoints or other consumers. Clones connect
+/// independently and share the same tls configuration.
 pub struct TlsConnector<IO> {
     inner: crate::client::TlsBoxedService<tokio_openssl::SslStream<IO>>,
+}
+
+// Manual impl because IO does not need to be Clone.
+impl<IO> Clone for TlsConnector<IO> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
@@ -49,7 +62,7 @@ impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
     /// }
     /// ```
     pub fn new(
-        transport: impl crate::Transport<Io = IO>,
+        transport: impl crate::Transport<Io = IO> + Sync,
         ssl_conn: openssl::ssl::SslConnector,
         domain: String,
     ) -> Self {

--- a/tonic-tls/src/openssl_ktls/client.rs
+++ b/tonic-tls/src/openssl_ktls/client.rs
@@ -30,6 +30,11 @@ impl crate::TlsConnector<TcpStream> for OpensslKtlsConnector {
 
 /// tonic client connector to connect to https endpoint at addr using
 /// openssl settings in ssl.
+///
+/// The connector is cloneable, so it can be created once and cloned to be
+/// passed to separate tonic endpoints or other consumers. Clones connect
+/// independently and share the same tls configuration.
+#[derive(Clone)]
 pub struct TlsConnector {
     inner: crate::client::TlsBoxedService<openssl_ktls::TokioSslStream>,
 }
@@ -52,7 +57,7 @@ impl TlsConnector {
     /// }
     /// ```
     pub fn new(
-        transport: impl crate::Transport<Io = TcpStream>,
+        transport: impl crate::Transport<Io = TcpStream> + Sync,
         ssl_conn: openssl::ssl::SslConnector,
         domain: String,
     ) -> Self {

--- a/tonic-tls/src/openssl_ktls/client.rs
+++ b/tonic-tls/src/openssl_ktls/client.rs
@@ -57,7 +57,7 @@ impl TlsConnector {
     /// }
     /// ```
     pub fn new(
-        transport: impl crate::Transport<Io = TcpStream> + Sync,
+        transport: impl crate::Transport<Io = TcpStream>,
         ssl_conn: openssl::ssl::SslConnector,
         domain: String,
     ) -> Self {

--- a/tonic-tls/src/rustls/client.rs
+++ b/tonic-tls/src/rustls/client.rs
@@ -27,8 +27,21 @@ where
 
 /// tonic client connector to connect to https endpoint at addr using
 /// rustls.
+///
+/// The connector is cloneable, so it can be created once and cloned to be
+/// passed to separate tonic endpoints or other consumers. Clones connect
+/// independently and share the same tls configuration.
 pub struct TlsConnector<IO> {
     inner: crate::client::TlsBoxedService<TlsStream<IO>>,
+}
+
+// Manual impl because IO does not need to be Clone.
+impl<IO> Clone for TlsConnector<IO> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
@@ -51,7 +64,7 @@ impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
     /// }
     /// ```
     pub fn new(
-        transport: impl crate::Transport<Io = IO>,
+        transport: impl crate::Transport<Io = IO> + Sync,
         ssl_conn: Arc<tokio_rustls::rustls::ClientConfig>,
         domain: tokio_rustls::rustls::pki_types::ServerName<'static>,
     ) -> Self {

--- a/tonic-tls/src/rustls/client.rs
+++ b/tonic-tls/src/rustls/client.rs
@@ -64,7 +64,7 @@ impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
     /// }
     /// ```
     pub fn new(
-        transport: impl crate::Transport<Io = IO> + Sync,
+        transport: impl crate::Transport<Io = IO>,
         ssl_conn: Arc<tokio_rustls::rustls::ClientConfig>,
         domain: tokio_rustls::rustls::pki_types::ServerName<'static>,
     ) -> Self {

--- a/tonic-tls/src/schannel/client.rs
+++ b/tonic-tls/src/schannel/client.rs
@@ -36,8 +36,21 @@ where
 
 /// tonic client connector to connect to https endpoint at addr using
 /// schannel.
+///
+/// The connector is cloneable, so it can be created once and cloned to be
+/// passed to separate tonic endpoints or other consumers. Clones connect
+/// independently and share the same tls configuration.
 pub struct TlsConnector<IO> {
     inner: crate::client::TlsBoxedService<TlsStream<IO>>,
+}
+
+// Manual impl because IO does not need to be Clone.
+impl<IO> Clone for TlsConnector<IO> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
@@ -58,7 +71,7 @@ impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
     /// }
     /// ```
     pub fn new(
-        transport: impl crate::Transport<Io = IO>,
+        transport: impl crate::Transport<Io = IO> + Sync,
         builder: schannel::tls_stream::Builder,
         cred: schannel::schannel_cred::SchannelCred,
     ) -> Self {

--- a/tonic-tls/src/schannel/client.rs
+++ b/tonic-tls/src/schannel/client.rs
@@ -71,7 +71,7 @@ impl<IO: AsyncRead + AsyncWrite + Send + Unpin + 'static> TlsConnector<IO> {
     /// }
     /// ```
     pub fn new(
-        transport: impl crate::Transport<Io = IO> + Sync,
+        transport: impl crate::Transport<Io = IO>,
         builder: schannel::tls_stream::Builder,
         cred: schannel::schannel_cred::SchannelCred,
     ) -> Self {


### PR DESCRIPTION
Fixes #64

## Summary

All public client connectors (`native`, `openssl`, `openssl_ktls`, `rustls`, `schannel`) now implement `Clone`, so a connector can be constructed once and reused across multiple consumers by cloning it.

## Implementation

- `TlsBoxedService` switches from `tower::util::BoxService` to `tower::util::BoxCloneSyncService`.
- `Clone` is implemented for every public backend `TlsConnector`.

### Why `BoxCloneSyncService` and not `BoxCloneService`

The issue proposed `BoxCloneService`. That turns out to silently regress an auto trait: `BoxService` stores its inner service in a `SyncWrapper`, which makes it `Sync` even though the boxed trait object is not. `BoxCloneService` cannot do this — `Clone::clone` needs `&self` access, which is exactly what `SyncWrapper` forbids — so the connectors would have quietly stopped being `Sync`, breaking anything that shares them behind an `Arc` or hits a `Sync` bound.

`BoxCloneSyncService` keeps `Sync` and adds `Clone`. The cost is that the transport, tls connector and connect argument must be `Sync`, so `+ Sync` bounds are added to `connector_inner` and to each backend's `new`.

### Why `Clone` is implemented manually

`#[derive(Clone)]` would generate `impl<IO: Clone> Clone`, and `IO` is the transport stream (e.g. `TcpStream`), which is not `Clone`, so the impl would never apply:

```
error[E0599]: the method `clone` exists for struct `TlsConnector<TcpStream>`,
but its trait bounds were not satisfied
```

`IO` only appears inside the boxed service's type argument, so the manual impl drops the spurious bound. `openssl_ktls::TlsConnector` has no type parameter and uses `#[derive(Clone)]`.

## Tests

Each backend gets a test that builds a connector, clones it, and drives a gRPC request through each clone independently. The existing `connect_*_tonic_channel` helpers are refactored to build their connector through the new `make_*_connector` functions, removing the duplicated setup.

## Compatibility

Breaking for direct users of the publicly re-exported `connector_inner` (its return type changes) and for custom `Transport`/`TlsConnector` impls that are not `Sync`. Crate version bumped to `0.8.0`.

## Verification

- `cargo fmt --check` clean, `cargo clippy --all-targets --all-features` clean.
- `cargo test --all-features` passes (11/11 on Linux). `tests::example_test` fails locally both with and without this change, so it is unrelated.
- Windows-only schannel code verified with `cargo check --target x86_64-pc-windows-msvc`; the schannel test itself runs on the `windows-latest` CI leg.
- `Sync` preservation checked explicitly against the pre-change baseline.